### PR TITLE
Add mode `jq-script`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -843,6 +843,7 @@ dependencies = [
  "sha2",
  "thiserror",
  "tokio",
+ "tokio-util",
  "url",
 ]
 
@@ -1103,6 +1104,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "signal-hook-registry"
+version = "1.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d8229b473baa5980ac72ef434c4415e70c4b5e71b423043adb4ba059f89c99a1"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "slab"
 version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1217,6 +1227,7 @@ dependencies = [
  "mio",
  "num_cpus",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2 0.5.4",
  "windows-sys",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,10 +14,11 @@ url = { version = "2.4.1", default-features = false, features = ["serde"] }
 serde_json = { version = "1.0.107", default-features = false, features = ["std", "preserve_order"] }
 thiserror = { version = "1.0.49", default-features = false }
 futures = { version = "0.3.28", default-features = false, features = ["std"] }
-itertools = "0.11.0"
-tokio = { version = "1.32.0", default-features = false, features = ["rt", "rt-multi-thread"] }
+itertools = { version = "0.11.0", default-features = false, features = ["use_std"] }
+tokio = { version = "1.32.0", default-features = false, features = ["rt", "rt-multi-thread", "process", "io-util"] }
 sha2 = { version = "0.10.8", default-features = false, features = ["std"] }
 regex = { version = "1.9.6", default-features = false, features = ["std", "perf"] }
+tokio-util = { version = "0.7.9", default-features = false, features = ["io"] }
 
 [dev-dependencies]
 rstest = { version = "0.18.2", default-features = false }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,7 +1,8 @@
 pub mod pkg_info;
+mod reqwest_utils;
 mod serde_utils;
 
 pub use pkg_info::{
     Arch, Base as PkgInfoBase, BashCmdReleaseHandler, Digest, GithubReleaseHandler,
-    Mode as PkgInfoMode, ModeGetLatestVersion, PkgInfo, VersionedArchEntry,
+    JqScriptReleaseHandler, Mode as PkgInfoMode, ModeGetLatestVersion, PkgInfo, VersionedArchEntry,
 };

--- a/src/pkg_info.rs
+++ b/src/pkg_info.rs
@@ -10,7 +10,9 @@ use std::{
 use serde::{Deserialize, Serialize};
 use url::Url;
 
-pub use mode::{BashCmdReleaseHandler, GithubReleaseHandler, Mode, ModeGetLatestVersion};
+pub use mode::{
+    BashCmdReleaseHandler, GithubReleaseHandler, JqScriptReleaseHandler, Mode, ModeGetLatestVersion,
+};
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 pub struct PkgInfo<'a> {

--- a/src/pkg_info/mode.rs
+++ b/src/pkg_info/mode.rs
@@ -1,5 +1,7 @@
 mod bash_command;
+mod external_cmd;
 mod github;
+mod jq_script;
 
 use std::{fmt::Debug, future::Future, path::Path, pin::Pin};
 
@@ -9,12 +11,14 @@ use super::Version;
 
 pub use bash_command::ReleaseHandler as BashCmdReleaseHandler;
 pub use github::ReleaseHandler as GithubReleaseHandler;
+pub use jq_script::ReleaseHandler as JqScriptReleaseHandler;
 
 #[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
 #[serde(rename_all = "kebab-case", tag = "mode")]
 pub enum Mode<'a> {
     GithubRelease(#[serde(borrow)] github::ReleaseHandler<'a>),
     BashCommand(#[serde(borrow)] bash_command::ReleaseHandler<'a>),
+    JqScript(#[serde(borrow)] jq_script::ReleaseHandler<'a>),
 }
 
 pub type BoxedFuture<Output> = Pin<Box<dyn Future<Output = Output>>>;
@@ -28,6 +32,7 @@ impl<'a> Mode<'a> {
         match self {
             Mode::GithubRelease(gh_release) => gh_release.get_latest_version(tmp_dir, in_test_mode),
             Mode::BashCommand(command) => command.get_latest_version(tmp_dir, in_test_mode),
+            Mode::JqScript(script) => script.get_latest_version(tmp_dir, in_test_mode),
         }
     }
 }

--- a/src/pkg_info/mode/external_cmd.rs
+++ b/src/pkg_info/mode/external_cmd.rs
@@ -1,0 +1,37 @@
+use std::{borrow::Cow, process::Output};
+
+use anyhow::Context;
+use serde::{Deserialize, Serialize};
+
+use crate::{pkg_info::Version, VersionedArchEntry};
+
+pub fn process_output(output: Output) -> anyhow::Result<(String, Version<'static>)> {
+    let string = String::from_utf8(output.stdout).context("Invalid utf-8 in output")?;
+    let info =
+        serde_json::from_str::<OutputVersionInfo>(&string).context("Failed to parse output")?;
+
+    Ok((
+        info.version.to_string(),
+        info.assets
+            .iter()
+            .map(|(k, v)| {
+                (
+                    *k,
+                    VersionedArchEntry {
+                        filename: Cow::Owned(v.filename.to_string()),
+                        download_url: v.download_url.clone(),
+                        digest: v.digest.to_owned(),
+                    },
+                )
+            })
+            .collect(),
+    ))
+}
+
+#[derive(Debug, Serialize, Deserialize)]
+struct OutputVersionInfo<'a> {
+    #[serde(borrow)]
+    version: &'a str,
+    #[serde(borrow)]
+    assets: Version<'a>,
+}

--- a/src/pkg_info/mode/jq_script.rs
+++ b/src/pkg_info/mode/jq_script.rs
@@ -1,0 +1,75 @@
+use std::{path::Path, process::Stdio};
+
+use anyhow::{Context, Ok};
+use futures::TryStreamExt;
+use serde::{Deserialize, Serialize};
+use tokio::process::Command;
+
+use crate::ModeGetLatestVersion;
+
+#[derive(Debug, Serialize, Deserialize, PartialEq, Eq)]
+#[serde(rename_all = "kebab-case")]
+pub struct ReleaseHandler<'a> {
+    pub document_url: url::Url,
+    #[serde(borrow)]
+    pub script_path: &'a Path,
+}
+
+impl<'a> ModeGetLatestVersion for ReleaseHandler<'a> {
+    fn get_latest_version(
+        &self,
+        _tmp_dir: &Path,
+        _in_test_mode: bool,
+    ) -> anyhow::Result<
+        super::BoxedFuture<anyhow::Result<(String, crate::pkg_info::Version<'static>)>>,
+    > {
+        let document_url = self.document_url.clone();
+        let script_path = self.script_path.to_path_buf();
+        let http_client = crate::reqwest_utils::prepare_http_client_json()
+            .build()
+            .context("Failed to build http client")?;
+
+        let mut cmd = Command::new("jq");
+        cmd.arg("--from-file")
+            .arg(script_path)
+            .stdin(Stdio::piped())
+            .stdout(Stdio::piped())
+            .stderr(Stdio::inherit());
+
+        Ok(Box::pin(async move {
+            log::info!("Requesting json document ...");
+            let document_resp = http_client.get(document_url).send().await?;
+            anyhow::ensure!(
+                document_resp.status() == reqwest::StatusCode::OK,
+                "Invalid response status"
+            );
+            let mut document_reader = tokio_util::io::StreamReader::new(
+                document_resp
+                    .bytes_stream()
+                    .map_err(|e| std::io::Error::new(std::io::ErrorKind::Other, e)),
+            );
+
+            log::info!("Spawning jq command ...");
+            let mut process = cmd.spawn()?;
+
+            let mut stdin = process
+                .stdin
+                .take()
+                .expect("Missing stdin to send document data");
+
+            log::info!("Streaming json document to jq ...");
+            let bytes_streamed = tokio::io::copy(&mut document_reader, &mut stdin)
+                .await
+                .context("Failed to stream json document to jq's stdin")?;
+            drop(stdin);
+
+            log::trace!("Streamed {} bytes to jq's stdin", bytes_streamed);
+
+            log::info!("Waiting for jq to finish ...");
+            let output = process.wait_with_output().await?;
+
+            anyhow::ensure!(output.status.success(), "Jq command has failed");
+            super::external_cmd::process_output(output)
+        }))
+    }
+}

--- a/src/reqwest_utils.rs
+++ b/src/reqwest_utils.rs
@@ -1,0 +1,13 @@
+use reqwest::{
+    header::{HeaderMap, HeaderValue, ACCEPT, USER_AGENT},
+    ClientBuilder,
+};
+
+pub fn prepare_http_client_json() -> ClientBuilder {
+    ClientBuilder::default()
+        .gzip(true)
+        .default_headers(HeaderMap::from_iter([
+            (USER_AGENT, HeaderValue::from_static("pkg-info-updater")),
+            (ACCEPT, HeaderValue::from_static("application/json")),
+        ]))
+}

--- a/tests/samples/minimal-jq-script.json
+++ b/tests/samples/minimal-jq-script.json
@@ -1,0 +1,6 @@
+{
+  "name": "Sonarr",
+  "mode": "jq-script",
+  "document-url": "https://services.sonarr.tv/v1/releases",
+  "script-path": "sonarr.jq"
+}

--- a/tests/schema.rs
+++ b/tests/schema.rs
@@ -4,8 +4,8 @@ use regex::Regex;
 use rstest::rstest;
 
 use pkg_info_update::{
-    Arch, BashCmdReleaseHandler, Digest, GithubReleaseHandler, PkgInfo, PkgInfoBase, PkgInfoMode,
-    VersionedArchEntry,
+    Arch, BashCmdReleaseHandler, Digest, GithubReleaseHandler, JqScriptReleaseHandler, PkgInfo,
+    PkgInfoBase, PkgInfoMode, VersionedArchEntry,
 };
 
 #[rstest]
@@ -32,6 +32,20 @@ use pkg_info_update::{
         base: PkgInfoBase { name: "Foobar", latest_version: None, versions: None },
         mode: PkgInfoMode::BashCommand(BashCmdReleaseHandler {
             command: Cow::Borrowed(r#"echo '{ "version": "0.1.0", "assets": { "amd64": { "filename": "foobar", "download_url": "https://google.com", "digest": "sha256:e8bf04349572f90e569c5bd46be3f7101e1e289125adb8b9eaba94badba1c43a" } } }'"#)
+        })
+    }
+)]
+#[case::minimal_jq_script(
+    std::include_str!("samples/minimal-jq-script.json"),
+    PkgInfo {
+        base: PkgInfoBase {
+            name: "Sonarr",
+            latest_version: None,
+            versions: None
+        },
+        mode: PkgInfoMode::JqScript(JqScriptReleaseHandler {
+            document_url: url::Url::parse("https://services.sonarr.tv/v1/releases").unwrap(),
+            script_path: "sonarr.jq".as_ref()
         })
     }
 )]


### PR DESCRIPTION
Provide a mode that will execute a jq script after downloading a json document.
The expected output of jq-script is the same as for `bash-command`.
