### PR TITLE
Add gh actions to get the version to use for a package 

### DIFF
--- a/.github/actions/pkg-version-to-use/action.sh
+++ b/.github/actions/pkg-version-to-use/action.sh
@@ -1,0 +1,23 @@
+#!/usr/bin/env bash
+
+set -eu -o pipefail
+
+LATEST_VERSION=$(jq -r .latest_version "$PKG_FILE")
+
+if [ -z "$PKG_VERSION" ]; then
+  PKG_VERSION="$LATEST_VERSION"
+fi
+
+if jq -r '.versions | keys[]' "$PKG_FILE" | grep -e "$PKG_VERSION"; then
+  (
+    echo "version=$PKG_VERSION"
+    if [ "$LATEST_VERSION" == "$PKG_VERSION" ]; then
+      echo is_latest=true
+    else
+      echo is_latest=false
+    fi
+  ) | tee -a $GITHUB_OUTPUT
+else
+  echo "The specified version ($PKG_VERSION) is not listed in the package file ($PKG_FILE)" >&2
+  exit 1
+fi

--- a/.github/actions/pkg-version-to-use/action.yml
+++ b/.github/actions/pkg-version-to-use/action.yml
@@ -1,0 +1,30 @@
+name: Pkg version to use
+description: Determine which version to use and if it is the latest version
+
+inputs:
+  pkg-file:
+    default: pkg-info.json
+    required: true
+    description: The path to the pkg-info file.
+  pkg-version:
+    required: false
+    description: The desired pkg version to use.
+
+outputs:
+  version:
+    description: The version to use.
+    value: ${{ steps.script.outputs.version }}
+  is-latest:
+    description: True if the version to use is the latest one.
+    value: ${{ steps.script.outputs.is_latest }}
+
+runs:
+  using: composite
+  steps:
+    - name: foo
+      id: script
+      shell: bash
+      run: ./.github/actions/pkg-version-to-use/action.sh
+      env:
+        PKG_FILE: ${{ inputs.pkg-file }}
+        PKG_VERSION: ${{ inputs.pkg-version }}

--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -3,10 +3,15 @@ name: Build & Publish docker
 on:
   workflow_call:
     inputs:
+      pkg-file:
+        type: string
+        description: The path to the pkg-info file
+        default: pkg-info.json
+        required: true
       pkg-version:
         type: string
-        description: The version of the package
-        required: true
+        description: The version of the package (latest by default)
+        required: false
       registry:
         type: string
         description: The registry to push the images to.
@@ -18,6 +23,10 @@ on:
       docker-username:
         type: string
         description: The username to use with `docker login -u ..`
+        required: true
+      docker-repository:
+        type: string
+        description: The repository to push the image to (could be `FooBar/project42`).
         required: true
       platforms:
         type: string
@@ -39,6 +48,13 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Determine pkg version to use
+        id: pkg-vers
+        uses: ./.github/actions/pkg-version-to-use
+        with:
+          pkg-file: ${{ inputs.pkg-file }}
+          pkg-version: ${{ inputs.pkg-version }}
 
       # Install the cosign tool except on PR
       # https://github.com/sigstore/cosign-installer
@@ -62,6 +78,16 @@ jobs:
           username: ${{ inputs.docker-username }}
           password: ${{ secrets.docker-password }}
 
+      - name: Generate tags & label
+        uses: docker/metadata-action@96383f45573cb7f253c731d3b3ab81c87ef81934 # v5.0.0
+        id: metadata
+        with:
+          images: ${{ inputs.registry }}/${{ inputs.docker-repository }}
+          tags:
+            type=raw,value=${{ steps.pkg-vers.outputs.version }}
+          flavor: |
+            latest=${{ steps.pkg-vers.outputs.is-latest == 'true' }}
+
       # Build and push Docker image with Buildx (don't push on PR)
       # https://github.com/docker/build-push-action
       - name: Build and push Docker image
@@ -72,9 +98,9 @@ jobs:
           provenance: mode=max
           sbom: true
           platforms: ${{ inputs.platforms }}
-          build-args: PKG_VERSION=${{ inputs.pkg-version }}
+          build-args: PKG_VERSION=${{ steps.pkg-vers.outputs.version }}
           push: ${{ github.event_name != 'pull_request' }}
-          tags: ${{ inputs.tags }}
+          tags: ${{ steps.metadata.outputs.tags }}
           cache-from: type=gha
           cache-to: type=gha,mode=max
 

--- a/.github/workflows/test-pkg-version-to-use.yml
+++ b/.github/workflows/test-pkg-version-to-use.yml
@@ -1,0 +1,85 @@
+name: Test action called workflow ref
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - .github/workflows/test-pkg-version-to-use.yml
+      - .github/actions/pkg-version-to-use/*
+  pull_request:
+    paths:
+      - .github/workflows/test-pkg-version-to-use.yml
+      - .github/actions/pkg-version-to-use/*
+
+jobs:
+  test:
+    name: Test action called workflow ref
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@b4ffde65f46336ab88eb53be808477a3936bae11 # v4.1.1
+
+      - name: Generate dummy pkg-info file
+        run: |
+          cat << EOF | tee dummy-pkg-info.json
+          {
+            "latest_version": "1.2.3",
+            "versions": {
+              "1.2.3": {},
+              "1.0.0": {},
+              "0.0.0": {}
+            }
+          }
+          EOF
+
+      # With no pkg-version specified, the action should return the latest version.
+      - name: Get latest version
+        id: lst-pkg-ver
+        uses: ./.github/actions/pkg-version-to-use
+        with:
+          pkg-file: dummy-pkg-info.json
+          pkg-version: ''
+
+      - name: We got the latest version
+        run: >
+          [ '${{ steps.lst-pkg-ver.outputs.is-latest }}' == 'true' ] &&
+          [ '${{ steps.lst-pkg-ver.outputs.version }}' == '1.2.3' ]
+
+      # If we specify the version and it's the latest version, `is-latest` should be set.
+      - name: Get latest version explicitly
+        id: lst-fix-pkg-ver
+        uses: ./.github/actions/pkg-version-to-use
+        with:
+          pkg-file: dummy-pkg-info.json
+          pkg-version: '1.2.3'
+
+      - name: We got the latest version explicitly
+        run: >
+          [ '${{ steps.lst-fix-pkg-ver.outputs.is-latest }}' == 'true' ] &&
+          [ '${{ steps.lst-fix-pkg-ver.outputs.version }}' == '1.2.3' ]
+
+      # If we get an old version, `is-latest` should be false.
+      - name: Get old version
+        id: old-pkg-ver
+        uses: ./.github/actions/pkg-version-to-use
+        with:
+          pkg-file: dummy-pkg-info.json
+          pkg-version: '1.0.0'
+
+      - name: We got the old version
+        run: >
+          [ '${{ steps.old-pkg-ver.outputs.is-latest }}' == 'false' ] &&
+          [ '${{ steps.old-pkg-ver.outputs.version }}' == '1.0.0' ]
+
+      # If we try to get an unknown version, the action should fail
+      - name: Get Unknown version
+        id: unknown-ver
+        uses: ./.github/actions/pkg-version-to-use
+        with:
+          pkg-file: dummy-pkg-info.json
+          pkg-version: '0.0.42'
+        continue-on-error: true
+
+      - name: Unknown version should fail
+        run: >
+          [ '${{ steps.unknown-ver.outcome }}' == 'failure' ]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,51 @@
+# GH-actions-workflows-docker-services
+
+## Unreleased
+
+### Docker-build-publish workflow
+
+- Add the following required inputs:
+  - `pkg-file`: The path to the `pkg-file` (default to `pkg-info.json`).
+  - **(BREAKING CHANGE)** `docker-repository`: The repository name to push the image.
+- The input `pkg-version` is now optional (will use the latest version defined in `pkg-file`).
+
+### Internal change
+
+- Add action `pkg-version-to-use`.
+
+  The action will:
+
+  - Take 2 inputs:
+    - The desired package version (optional).
+    - The package file path.
+  - If we don't provide the package version, it will use the latest version defined in the package file.
+  - Will ensure the selected version is defined in the package file.
+  - Return 2 outputs:
+    - The version to use either the version provided or latest.
+    - A boolean if the returned version is the latest version.
+
+  ```mermaid
+  flowchart TB
+    IN_VER[Package version]
+    IN_FILE[Package file]
+    OUT_VER[version to use]
+    OUT_LATEST[version is latest]
+
+    IN_VER & IN_FILE --> ACT
+    ACT --> OUT_VER
+    ACT --> OUT_LATEST
+
+    subgraph ACT[pkg-version-to-use]
+      direction TB
+      VER_SEL{version is set ?}
+      USE_LATEST[Use latest version]
+      VER_EXIST{version exist ?}
+      VER_LATEST{version is latest ?}
+
+      VER_SEL -- YES --> VER_EXIST
+      VER_SEL -- NO --> USE_LATEST --> VER_EXIST
+
+      VER_EXIST -- NO --> ACT_FAIL[The action fail]
+      VER_EXIST -- YES --> VER_LATEST
+    end
+  ```


### PR DESCRIPTION
That action will:

- Default to the latest version if not provided.
- Indicate that the version is the latest one.
- Check the used version is specified in the pkg-info file.

Alongside we have a workflow that test the action.