### PR TITLE
Fix `can't find 'action.yml'`

### DIFF
--- a/.github/workflows/docker-build-publish.yml
+++ b/.github/workflows/docker-build-publish.yml
@@ -49,7 +49,7 @@ jobs:
 
       - name: Determine pkg version to use
         id: pkg-vers
-        uses: ./.github/actions/pkg-version-to-use
+        uses: FirelightFlagboy/gh-actions-workflows-docker-services/.github/actions/pkg-version-to-use@c69fa0ea29498dd15ce04b751dea05c272934c39
         with:
           pkg-file: ${{ inputs.pkg-file }}
           pkg-version: ${{ inputs.pkg-version }}

--- a/.github/workflows/update-pkg-info.yml
+++ b/.github/workflows/update-pkg-info.yml
@@ -26,7 +26,7 @@ jobs:
 
       - name: Retrieve called workflow ref
         id: workflow
-        uses: ./.github/actions/called-workflow-ref
+        uses: FirelightFlagboy/gh-actions-workflows-docker-services/.github/actions/called-workflow-ref@c69fa0ea29498dd15ce04b751dea05c272934c39
         with:
           called-repository: FirelightFlagboy/gh-actions-workflows-docker-services
           called-workflow-path: .github/workflows/update-pkg-info.yml

--- a/UNRELEASED-CHANGELOG.md
+++ b/UNRELEASED-CHANGELOG.md
@@ -72,3 +72,8 @@
       VER_EXIST -- YES --> VER_LATEST
     end
   ```
+
+- Fix `can't find 'action.yml'` ([#28](https://github.com/FirelightFlagboy/gh-actions-workflows-docker-services/issues/28) & [#29](https://github.com/FirelightFlagboy/gh-actions-workflows-docker-services/issues/29))
+
+  The reusable workflows `docker-build-publish` & `update-pkg-info` used local action that doesn't exist when called from an external repository
+  Because the action aren't present.

--- a/script/make-release.sh
+++ b/script/make-release.sh
@@ -59,6 +59,13 @@ function update_changelog {
   sed -i '/markdownlint-configure-file/!d' UNRELEASED-CHANGELOG.md
 }
 
+function update_gh_workflows {
+  sed -i \
+    "s;\(uses: FirelightFlagboy/gh-actions-workflows-docker-services\)/\(.*\)@.*;\1/\2@v$NEW_VERSION;" \
+    .github/workflows/docker-build-publish.yml \
+    .github/workflows/update-pkg-info.yml
+}
+
 function commit_file_for_release {
   git add pkg-info.json Cargo.toml Cargo.lock CHANGELOG.md UNRELEASE-CHANGELOG.md
   git commit --signoff --gpg-sign -m "Prepare for release $NEW_VERSION"
@@ -95,6 +102,8 @@ TEMP_FILES+=($RELEASE_BLOB)
 changelog_for_release > $RELEASE_BLOB
 
 update_changelog
+
+update_gh_workflows
 
 if [ $SKIP_RELEASE_CREATION -ne 0 ]; then
   echo "SKIP_RELEASE_CREATION set, skipping release creation"


### PR DESCRIPTION
The reusable workflows `docker-build-publish` & `update-pkg-info` used local action that doesn't exist when called from an external repository Because the action aren't present.

Closes #28, Closes #29